### PR TITLE
remove allowtransparency attribute from iframe

### DIFF
--- a/src/PaymentPage.js
+++ b/src/PaymentPage.js
@@ -10,7 +10,6 @@ const PaymentPage = props => {
     id='datatransPaymentFrame'
     name='datatransPaymentFrame'
     frameBorder={0}
-    allowTransparency={true}
   />
 }
 


### PR DESCRIPTION
Getting:
Warning: React does not recognize the `allowTransparency` prop on a DOM element. If you intentionally want it to appear in the DOM as a custom attribute, spell it as lowercase `allowtransparency` instead. If you accidentally passed it from a parent component, remove it from the DOM element.

Besides: 
HTML5 no longer allows the allowtransparency attribute on an <iframe> element.